### PR TITLE
feat: add refund locktimes list for batch dlc txs

### DIFF
--- a/include/cfddlc/cfddlc_transactions.h
+++ b/include/cfddlc/cfddlc_transactions.h
@@ -713,7 +713,7 @@ class CFD_DLC_EXPORT DlcManager {
     const std::vector<std::vector<DlcOutcome>> &outcomes_list,
     const BatchPartyParams &local_params,
     const BatchPartyParams &remote_params,
-    uint64_t refund_locktime,
+    std::vector<uint64_t> refund_locktimes,
     uint32_t fee_rate,
     const uint64_t fund_lock_time = 0,
     const uint64_t cet_lock_time = 0,

--- a/src/cfddlc_transactions.cpp
+++ b/src/cfddlc_transactions.cpp
@@ -711,7 +711,7 @@ BatchDlcTransactions DlcManager::CreateBatchDlcTransactions(
   const std::vector<std::vector<DlcOutcome>> &outcomes_list,
   const BatchPartyParams &local_params,
   const BatchPartyParams &remote_params,
-  uint64_t refund_locktime,
+  std::vector<uint64_t> refund_locktimes,
   uint32_t fee_rate,
   const uint64_t fund_lock_time,
   const uint64_t cet_lock_time,
@@ -866,7 +866,8 @@ BatchDlcTransactions DlcManager::CreateBatchDlcTransactions(
     auto refund_tx = CreateRefundTransaction(
       local_params.final_script_pubkeys[i],
       remote_params.final_script_pubkeys[i], local_params.collaterals[i],
-      remote_params.collaterals[i], refund_locktime, fund_tx_id, fund_vouts[i]);
+      remote_params.collaterals[i], refund_locktimes[i], fund_tx_id,
+      fund_vouts[i]);
 
     refund_txs.push_back(refund_tx);
   }

--- a/test/test_cfddlc_transactions.cpp
+++ b/test/test_cfddlc_transactions.cpp
@@ -671,10 +671,11 @@ TEST(DlcManager, CreateBatchDlcTransactions) {
   std::vector<DlcOutcome> outcomes = {
     {WIN_AMOUNT, LOSE_AMOUNT}, {LOSE_AMOUNT, WIN_AMOUNT}};
   std::vector<std::vector<DlcOutcome>> outcomes_batch = {outcomes, outcomes};
+  std::vector<uint64_t> refund_locktimes = {REFUND_LOCKTIME, REFUND_LOCKTIME};
 
   // Act
   auto dlc_transactions = DlcManager::CreateBatchDlcTransactions(
-    outcomes_batch, LOCAL_BATCH_PARAMS, REMOTE_BATCH_PARAMS, REFUND_LOCKTIME,
+    outcomes_batch, LOCAL_BATCH_PARAMS, REMOTE_BATCH_PARAMS, refund_locktimes,
     1);
   auto fund_tx = dlc_transactions.fund_transaction;
   DlcManager::SignFundTransactionInput(


### PR DESCRIPTION
## What

Add refund locktimes list for `CreateBatchDlcTransactions`

## Why

To allow a list of refund_locktimes to be passed in, allowing refund_locktime for each DLC to be custom / staggered