### PR TITLE
ci: modernize GitHub Actions workflow to fix Windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -26,14 +26,14 @@ jobs:
 
   cmake-win-test:
     name: cmake build-win
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
-        generator: ['Visual Studio 16 2019', 'MSYS Makefiles']
+        generator: ['Visual Studio 17 2022', 'MSYS Makefiles']
         shared: [on, off]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: cmake_version
       run: cmake --version
     - name: cmake_configure
@@ -47,10 +47,10 @@ jobs:
 
   cmake-mac-test:
     name: cmake build-mac
-    runs-on: self-hosted
+    runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: cmake_version
       run: cmake --version
     - name: cmake_configure
@@ -70,7 +70,7 @@ jobs:
         shared: [on, off]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: dump version
       run: |
         cmake --version


### PR DESCRIPTION
## Problem
The Windows CI builds were being cancelled immediately due to deprecated runners and outdated GitHub Actions.

## Solution
This PR modernizes the GitHub Actions workflow to fix the immediate cancellation issues:

### Changes Made
- **Windows Runner**: Updated from `windows-2019` (deprecated) to `windows-latest`
- **Visual Studio Generator**: Updated from 'Visual Studio 16 2019' to 'Visual Studio 17 2022'
- **GitHub Actions**: Upgraded all `actions/checkout` from v2 to v4
- **Mac Runner**: Changed from self-hosted to `macos-latest` (Apple Silicon ARM64)

### Why These Changes
- `windows-2019` is being phased out by GitHub and causes job cancellations
- `actions/checkout@v2` is deprecated and can cause security warnings/failures
- VS 2019 may not be available on newer Windows runners
- ARM64 macOS testing provides better coverage for Apple Silicon builds

### Testing
- Windows builds should now start successfully instead of being cancelled
- All runners use modern, supported versions
- ARM64 macOS builds will test Apple Silicon compatibility
- No functional changes to build process, only infrastructure updates

Fixes the immediate Windows build cancellation issues reported in the CI.